### PR TITLE
compressed utracy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,44 +19,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bincode"
@@ -80,10 +80,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -97,9 +98,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -107,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -119,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -131,15 +132,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "getrandom"
@@ -161,9 +168,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jobserver"
@@ -177,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "lz4"
@@ -221,10 +228,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "once_cell_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pkg-config"
@@ -234,18 +241,18 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -270,18 +277,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -302,9 +318,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unty"
@@ -345,77 +361,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,8 +84,16 @@ version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -134,6 +142,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,10 +166,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "libc"
-version = "0.2.153"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "lz4"
@@ -197,6 +227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,14 +251,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rtracy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bincode",
  "clap",
  "lz4",
  "num-derive",
  "num-traits",
+ "zeekstd",
 ]
 
 [[package]]
@@ -291,6 +334,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-sys"
@@ -364,3 +416,37 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zeekstd"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f1379c45a7b52ed4aa3442da2cf5cc39abf1d8d178a5c02797be29c072ede2"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ lz4 = "1.28.1"
 num-traits = "0.2.19"
 num-derive = "0.4.2"
 clap = { version = "4.5.54", features = ["derive"] }
+zeekstd = "0.6.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,6 @@ fn main() {
     let header: UTracyHeader =
         bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
 
-    dbg!(&header);
-
     if header.signature != FILE_SIGNATURE {
         println!(
             "Wrong utracy file signature, expected \"{FILE_SIGNATURE}\" got \"{}\"",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::enum_variant_names)]
 mod reader;
 mod server;
 mod structs;
@@ -14,7 +15,7 @@ use std::{str, thread};
 const FILE_SIGNATURE: u64 = 0x6D64796361727475;
 
 #[derive(Parser)]
-struct CLI {
+struct CliArgs {
     /// Utracy snapshot file
     file: String,
 
@@ -32,7 +33,7 @@ struct CLI {
 }
 
 fn main() {
-    let args = CLI::parse();
+    let args = CliArgs::parse();
 
     let mut file_reader = reader::ReadWrapper::open(&args.file);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,15 @@
-mod structs;
+mod reader;
 mod server;
+mod structs;
 
-use std::{str, thread};
-use std::collections::HashMap;
-use std::net::{SocketAddr, TcpListener};
-use std::io::SeekFrom;
-use std::fs::File;
-use std::io::BufReader;
-use std::io::prelude::*;
-use clap::Parser;
 use crate::server::handle_client;
-use crate::structs::{BINCODE_CONFIG, SourceLocation, UTracyHeader, UTracySourceLocation};
-
+use crate::structs::{SourceLocation, UTracyHeader, UTracySourceLocation, BINCODE_CONFIG};
+use clap::Parser;
+use std::collections::HashMap;
+use std::io::prelude::*;
+use std::io::SeekFrom;
+use std::net::{SocketAddr, TcpListener};
+use std::{str, thread};
 
 const FILE_SIGNATURE: u64 = 0x6D64796361727475;
 
@@ -36,22 +34,35 @@ struct CLI {
 fn main() {
     let args = CLI::parse();
 
-    let mut file_reader = BufReader::new(File::open(&args.file).expect("Error opening file"));
+    let mut file_reader = reader::ReadWrapper::open(&args.file);
 
-    let header: UTracyHeader = bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
+    let header: UTracyHeader =
+        bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
+
+    dbg!(&header);
 
     if header.signature != FILE_SIGNATURE {
-        println!("Wrong utracy file signature, expected \"{FILE_SIGNATURE}\" got \"{}\"", header.signature);
+        println!(
+            "Wrong utracy file signature, expected \"{FILE_SIGNATURE}\" got \"{}\"",
+            header.signature
+        );
         return;
     }
 
     if header.version != 2 {
-        println!("Wrong utracy file version, expected 2 got {}", header.version);
+        println!(
+            "Wrong utracy file version, expected 2 got {}",
+            header.version
+        );
         return;
     }
 
-    let location_count: u32 = bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
-    println!("Captured process: {}", str::from_utf8(&header.program_name).unwrap());
+    let location_count: u32 =
+        bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
+    println!(
+        "Captured process: {}",
+        str::from_utf8(&header.program_name).unwrap()
+    );
 
     println!("Found {} source locations", location_count);
     let mut locations = Vec::<SourceLocation>::with_capacity(location_count as usize);
@@ -59,35 +70,48 @@ fn main() {
     strings.insert(0, "".into());
 
     for i in 0..location_count {
-        let location: UTracySourceLocation = bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
+        let location: UTracySourceLocation =
+            bincode::decode_from_reader(&mut file_reader, BINCODE_CONFIG).unwrap();
 
         let mut name_string = location.name.get_hash();
-        while strings.get(&name_string).is_some_and(|t| t != &location.name.0) {
+        while strings
+            .get(&name_string)
+            .is_some_and(|t| t != &location.name.0)
+        {
             name_string += 1;
         }
         strings.insert(name_string, location.name.0);
 
         let mut function_string = location.function.get_hash();
-        while strings.get(&function_string).is_some_and(|t| t != &location.function.0) {
+        while strings
+            .get(&function_string)
+            .is_some_and(|t| t != &location.function.0)
+        {
             function_string += 1;
         }
         strings.insert(function_string, location.function.0);
 
         let mut file_string = location.file.get_hash();
-        while strings.get(&file_string).is_some_and(|t| t != &location.file.0) {
+        while strings
+            .get(&file_string)
+            .is_some_and(|t| t != &location.file.0)
+        {
             file_string += 1;
         }
         strings.insert(file_string, location.file.0);
 
-        locations.insert(i as usize, SourceLocation {
-            name: name_string,
-            function: function_string,
-            file: file_string,
-            line: location.line,
-            color_r: location.color[0],
-            color_g: location.color[1],
-            color_b: location.color[2],
-        });
+        locations.insert(
+            i as usize,
+            SourceLocation {
+                name: name_string,
+                function: function_string,
+                file: file_string,
+                line: location.line,
+                color_r: location.color[0],
+                color_g: location.color[1],
+                color_b: location.color[2],
+            },
+        );
     }
 
     let events_position = file_reader.stream_position().unwrap();
@@ -105,10 +129,18 @@ fn main() {
         match stream {
             Ok(stream) => {
                 println!("New connection: {}", stream.peer_addr().unwrap());
-                let mut file_reader = BufReader::new(File::open(&file_name_ref).expect("Error opening file"));
+                let mut file_reader = reader::ReadWrapper::open(&file_name_ref);
                 file_reader.seek(SeekFrom::Start(events_position)).unwrap();
                 thread::spawn(|| {
-                    if let Err(msg) = handle_client(stream, header_ref, locations_ref, strings_ref, file_reader, *skip_frames_ref, *limit_frames_ref) {
+                    if let Err(msg) = handle_client(
+                        stream,
+                        header_ref,
+                        locations_ref,
+                        strings_ref,
+                        file_reader,
+                        *skip_frames_ref,
+                        *limit_frames_ref,
+                    ) {
                         println!("Client disconnected with error: {}", msg)
                     }
                 });

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,92 @@
+use bincode::{de::read::Reader, error::DecodeError};
+use std::{
+    fs::File,
+    io::{BufReader, Seek},
+};
+use zeekstd::{Decoder, Seekable};
+
+pub enum ReadWrapper<'a> {
+    Uncompressed(BufReader<File>),
+    Compressed(Decoder<'a, File>),
+}
+
+impl<'a> ReadWrapper<'a> {
+    pub fn open(file_name: impl AsRef<str>) -> Self {
+        let file_name = file_name.as_ref();
+        let file = File::open(file_name).expect("Error opening file");
+        if file_name.ends_with(".zst") {
+            Self::Compressed(Decoder::new(file).expect("zstd decoder setup failed"))
+        } else {
+            Self::Uncompressed(BufReader::new(file))
+        }
+    }
+
+    fn read_impl_compressed(
+        compressed: &mut Decoder<'a, File>,
+        bytes: &mut [u8],
+    ) -> Result<(), DecodeError> {
+        let required = bytes.len();
+        let length = compressed
+            .read(bytes)
+            .map_err(|err| DecodeError::OtherString(err.to_string()))?;
+        if required > length {
+            Err(DecodeError::UnexpectedEnd {
+                additional: required - length,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a> Reader for ReadWrapper<'a> {
+    fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
+        match self {
+            Self::Uncompressed(reader) => Reader::read(reader, bytes),
+            Self::Compressed(compressed) => Self::read_impl_compressed(compressed, bytes),
+        }
+    }
+
+    fn peek_read(&mut self, v: usize) -> Option<&[u8]> {
+        match self {
+            Self::Uncompressed(reader) => reader.peek_read(v),
+            _ => None,
+        }
+    }
+
+    fn consume(&mut self, v: usize) {
+        if let Self::Uncompressed(reader) = self {
+            reader.consume(v);
+        }
+    }
+}
+
+impl<'a> Seek for ReadWrapper<'a> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Self::Uncompressed(reader) => reader.seek(pos),
+            Self::Compressed(reader) => reader.seek(pos),
+        }
+    }
+
+    fn rewind(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Uncompressed(reader) => reader.rewind(),
+            Self::Compressed(reader) => reader.rewind(),
+        }
+    }
+
+    fn stream_position(&mut self) -> std::io::Result<u64> {
+        match self {
+            Self::Uncompressed(reader) => reader.stream_position(),
+            Self::Compressed(reader) => reader.stream_position(),
+        }
+    }
+
+    fn seek_relative(&mut self, offset: i64) -> std::io::Result<()> {
+        match self {
+            Self::Uncompressed(reader) => reader.seek_relative(offset),
+            Self::Compressed(reader) => reader.seek_relative(offset),
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,15 +1,20 @@
+use crate::reader::ReadWrapper;
+use crate::structs::{
+    EventType, HandshakeStatus, NetworkFrameMark, NetworkHeader, NetworkMessageSourceLocation,
+    NetworkMessageString, NetworkQuery, NetworkSourceCode, NetworkThreadContext, NetworkZoneBegin,
+    NetworkZoneColor, NetworkZoneEnd, QueryResponseType, ServerQueryType, SourceLocation,
+    U16SizeString, UTracyEvent, UTracyHeader, WriterBox, BINCODE_CONFIG,
+};
+use bincode::de::read::Reader;
+use bincode::error::DecodeError;
+use bincode::error::DecodeError::Io;
+use bincode::Encode;
+use lz4::block::compress;
 use std::collections::HashMap;
-use std::fs::File;
 use std::io::{BufReader, BufWriter, ErrorKind, Write};
 use std::net::{Shutdown, TcpStream};
 use std::thread::sleep;
 use std::time::Duration;
-use bincode::de::read::Reader;
-use bincode::Encode;
-use bincode::error::DecodeError;
-use bincode::error::DecodeError::Io;
-use crate::structs::{BINCODE_CONFIG, WriterBox, EventType, HandshakeStatus, SourceLocation, UTracyEvent, UTracyHeader, NetworkZoneBegin, NetworkZoneEnd, NetworkZoneColor, NetworkFrameMark, NetworkQuery, NetworkThreadContext, NetworkHeader, QueryResponseType, NetworkMessageSourceLocation, NetworkMessageString, U16SizeString, ServerQueryType, NetworkSourceCode};
-use lz4::block::compress;
 
 struct ServerContext<'l> {
     socket: &'l TcpStream,
@@ -20,18 +25,21 @@ struct ServerContext<'l> {
     timestamp: u64,
     locations: &'l Vec<SourceLocation>,
     strings: &'l HashMap<u64, String>,
-    events_data: BufReader<File>,
+    events_data: ReadWrapper<'static>,
     skip_frames: u64,
     limit_frames: u64,
 }
 
 impl ServerContext<'_> {
     fn process_client(&mut self) -> Result<(), String> {
-        self.socket.set_nonblocking(true).map_err(|e| format!("{}", e))?;
+        self.socket
+            .set_nonblocking(true)
+            .map_err(|e| format!("{}", e))?;
         let mut read_event = 0;
         let mut frame = 0;
         loop {
-            let e1: Result<UTracyEvent, DecodeError> = bincode::decode_from_reader(&mut self.events_data, BINCODE_CONFIG);
+            let e1: Result<UTracyEvent, DecodeError> =
+                bincode::decode_from_reader(&mut self.events_data, BINCODE_CONFIG);
             if e1.is_err() {
                 println!("Reached end of file");
                 break;
@@ -95,7 +103,7 @@ impl ServerContext<'_> {
         }
         self.flush_buffer()?;
         println!("Sending done, wait 20 seconds to handle queries");
-        for _i in 0..2  {
+        for _i in 0..2 {
             if !self.process_query()? {
                 return Ok(());
             }
@@ -118,7 +126,9 @@ impl ServerContext<'_> {
                 }
             }
             result.map_err(|e| format!("{}", e))?;
-            let request: NetworkQuery = bincode::decode_from_slice(&buffer, BINCODE_CONFIG).unwrap().0;
+            let request: NetworkQuery = bincode::decode_from_slice(&buffer, BINCODE_CONFIG)
+                .unwrap()
+                .0;
             match request.query_type {
                 ServerQueryType::ServerQueryTerminate => {
                     return Ok(false);
@@ -158,10 +168,13 @@ impl ServerContext<'_> {
                         id: request.pointer as u32,
                     })?;
                 }
-                ServerQueryType::ServerQueryDataTransfer | ServerQueryType::ServerQueryDataTransferPart => {
+                ServerQueryType::ServerQueryDataTransfer
+                | ServerQueryType::ServerQueryDataTransferPart => {
                     self.send_message(QueryResponseType::AckServerQueryNoop)?;
                 }
-                _ => { println!("Unknown request {:?}", request.query_type) }
+                _ => {
+                    println!("Unknown request {:?}", request.query_type)
+                }
             };
         }
         self.flush_buffer()?;
@@ -180,13 +193,22 @@ impl ServerContext<'_> {
         if self.encoder.0.is_empty() {
             return Ok(());
         }
-        self.socket.set_nonblocking(false).map_err(|e| format!("{}", e))?;
-        let result = compress(self.encoder.0.as_slice(), None, false).map_err(|e| format!("{}", e))?;
-        self.writer.write(&u32::to_le_bytes(result.len() as u32)).map_err(|e| format!("{}", e))?;
-        self.writer.write(result.as_slice()).map_err(|e| format!("{}", e))?;
+        self.socket
+            .set_nonblocking(false)
+            .map_err(|e| format!("{}", e))?;
+        let result =
+            compress(self.encoder.0.as_slice(), None, false).map_err(|e| format!("{}", e))?;
+        self.writer
+            .write(&u32::to_le_bytes(result.len() as u32))
+            .map_err(|e| format!("{}", e))?;
+        self.writer
+            .write(result.as_slice())
+            .map_err(|e| format!("{}", e))?;
         self.writer.flush().map_err(|e| format!("{}", e))?;
         self.encoder.0.clear();
-        self.socket.set_nonblocking(true).map_err(|e| format!("{}", e))?;
+        self.socket
+            .set_nonblocking(true)
+            .map_err(|e| format!("{}", e))?;
         return Ok(());
     }
 
@@ -194,47 +216,78 @@ impl ServerContext<'_> {
         if self.last_thread_id != thread_id {
             self.last_thread_id = thread_id;
             self.timestamp = 0;
-            bincode::encode_into_writer(NetworkThreadContext {
-                query_type: QueryResponseType::ThreadContext,
-                thread_id,
-            }, &mut self.encoder, BINCODE_CONFIG).unwrap();
+            bincode::encode_into_writer(
+                NetworkThreadContext {
+                    query_type: QueryResponseType::ThreadContext,
+                    thread_id,
+                },
+                &mut self.encoder,
+                BINCODE_CONFIG,
+            )
+            .unwrap();
         }
     }
 }
 
-pub fn handle_client(stream: TcpStream, header: &UTracyHeader, locations: &Vec<SourceLocation>, strings: &HashMap<u64, String>, events_data: BufReader<File>, skip_frames: u32, limit_frames: u32) -> Result<(), String> {
+pub fn handle_client(
+    stream: TcpStream,
+    header: &UTracyHeader,
+    locations: &Vec<SourceLocation>,
+    strings: &HashMap<u64, String>,
+    events_data: ReadWrapper<'static>,
+    skip_frames: u32,
+    limit_frames: u32,
+) -> Result<(), String> {
     let mut reader = BufReader::new(&stream);
     let mut writer = BufWriter::new(&stream);
 
     let mut client_name = [0u8; 8];
-    reader.read(&mut client_name).map_err(|e| format!("{}", e))?;
+    reader
+        .read(&mut client_name)
+        .map_err(|e| format!("{}", e))?;
     if std::str::from_utf8(&client_name).unwrap() != "TracyPrf" {
-        return Err(format!("Invalid client, expected \"TracyPrf\", got {}", std::str::from_utf8(&client_name).unwrap()));
+        return Err(format!(
+            "Invalid client, expected \"TracyPrf\", got {}",
+            std::str::from_utf8(&client_name).unwrap()
+        ));
     }
-    let version: u32 = bincode::decode_from_reader(&mut reader, BINCODE_CONFIG).map_err(|e| format!("{}", e))?;
+    let version: u32 =
+        bincode::decode_from_reader(&mut reader, BINCODE_CONFIG).map_err(|e| format!("{}", e))?;
     if version != 76 {
-        writer.write(&[HandshakeStatus::HandshakeProtocolMismatch as u8]).map_err(|e| format!("{}", e))?;
-        return Err(format!("Invalid client version, expected 76, got {}", version));
+        writer
+            .write(&[HandshakeStatus::HandshakeProtocolMismatch as u8])
+            .map_err(|e| format!("{}", e))?;
+        return Err(format!(
+            "Invalid client version, expected 76, got {}",
+            version
+        ));
     }
 
-    writer.write(&[HandshakeStatus::HandshakeWelcome as u8]).map_err(|e| format!("{}", e))?;
+    writer
+        .write(&[HandshakeStatus::HandshakeWelcome as u8])
+        .map_err(|e| format!("{}", e))?;
     writer.flush().map_err(|e| format!("{}", e))?;
-    bincode::encode_into_writer(NetworkHeader {
-        multiplier: header.multiplier,
-        init_begin: header.init_begin,
-        init_end: header.init_end,
-        resolution: header.resolution,
-        epoch: header.epoch,
-        exec_time: header.exec_time,
-        process_id: header.process_id,
-        sampling_period: header.sampling_period,
-        flags: header.flags,
-        cpu_arch: header.cpu_arch,
-        cpu_manufacturer: header.cpu_manufacturer,
-        cpu_id: header.cpu_id,
-        program_name: header.program_name,
-        host_info: header.host_info,
-    }, WriterBox(&mut writer), BINCODE_CONFIG).map_err(|e| format!("{}", e))?;
+    bincode::encode_into_writer(
+        NetworkHeader {
+            multiplier: header.multiplier,
+            init_begin: header.init_begin,
+            init_end: header.init_end,
+            resolution: header.resolution,
+            epoch: header.epoch,
+            exec_time: header.exec_time,
+            process_id: header.process_id,
+            sampling_period: header.sampling_period,
+            flags: header.flags,
+            cpu_arch: header.cpu_arch,
+            cpu_manufacturer: header.cpu_manufacturer,
+            cpu_id: header.cpu_id,
+            program_name: header.program_name,
+            host_info: header.host_info,
+        },
+        WriterBox(&mut writer),
+        BINCODE_CONFIG,
+    )
+    .map_err(|e| format!("{}", e))?;
     writer.flush().map_err(|e| format!("{}", e))?;
 
     let mut buffer = Vec::new();
@@ -252,7 +305,9 @@ pub fn handle_client(stream: TcpStream, header: &UTracyHeader, locations: &Vec<S
         limit_frames: limit_frames.into(),
     };
     context.process_client()?;
-    stream.shutdown(Shutdown::Both).map_err(|e| format!("{}", e))?;
+    stream
+        .shutdown(Shutdown::Both)
+        .map_err(|e| format!("{}", e))?;
 
     return Ok(());
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -110,7 +110,7 @@ impl ServerContext<'_> {
             sleep(Duration::from_millis(10));
         }
 
-        return Ok(());
+        Ok(())
     }
 
     fn process_query(&mut self) -> Result<bool, String> {
@@ -178,7 +178,7 @@ impl ServerContext<'_> {
             };
         }
         self.flush_buffer()?;
-        return Ok(true);
+        Ok(true)
     }
 
     fn send_message<W: Encode>(&mut self, message: W) -> Result<(), String> {
@@ -186,7 +186,7 @@ impl ServerContext<'_> {
             self.flush_buffer()?
         }
         bincode::encode_into_writer(message, &mut self.encoder, BINCODE_CONFIG).unwrap();
-        return Ok(());
+        Ok(())
     }
 
     fn flush_buffer(&mut self) -> Result<(), String> {
@@ -209,7 +209,7 @@ impl ServerContext<'_> {
         self.socket
             .set_nonblocking(true)
             .map_err(|e| format!("{}", e))?;
-        return Ok(());
+        Ok(())
     }
 
     fn check_thread(&mut self, thread_id: u32) {
@@ -309,5 +309,5 @@ pub fn handle_client(
         .shutdown(Shutdown::Both)
         .map_err(|e| format!("{}", e))?;
 
-    return Ok(());
+    Ok(())
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -31,12 +31,12 @@ pub struct U32SizeString(pub String);
 
 impl U32SizeString {
     pub fn get_hash(&self) -> u64 {
-        if self.0.len() == 0 {
+        if self.0.is_empty() {
             return 0;
         }
         let mut hasher = DefaultHasher::new();
         self.0.hash(&mut hasher);
-        return hasher.finish();
+        hasher.finish()
     }
 }
 
@@ -54,15 +54,14 @@ impl<Context> Decode<Context> for U32SizeString {
     fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let len = u32::decode(decoder)?;
         decoder.claim_container_read::<u8>(len as usize)?;
-        let mut vec = Vec::new();
-        vec.resize(len as usize, 0u8);
+        let mut vec = vec![0; len as usize];
         decoder.reader().read(&mut vec)?;
-        return match String::from_utf8(vec) {
+        match String::from_utf8(vec) {
             Ok(result) => Ok(U32SizeString(result)),
             Err(e) => Err(DecodeError::Utf8 {
                 inner: e.utf8_error(),
             }),
-        };
+        }
     }
 }
 
@@ -123,14 +122,14 @@ bincode::impl_borrow_decode!(EventType);
 impl<Context> Decode<Context> for EventType {
     fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let value = u8::decode(decoder)?;
-        return match EventType::from_u8(value) {
+        match EventType::from_u8(value) {
             None => Err(DecodeError::UnexpectedVariant {
                 type_name: "event_type",
                 allowed: &Allowed(&[15, 17, 62, 64]),
                 found: value.into(),
             }),
             Some(v) => Ok(v),
-        };
+        }
     }
 }
 
@@ -200,7 +199,7 @@ pub enum HandshakeStatus {
 
 impl Encode for HandshakeStatus {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        return self.to_u8().unwrap().encode(encoder);
+        self.to_u8().unwrap().encode(encoder)
     }
 }
 
@@ -460,6 +459,6 @@ pub enum QueryResponseType {
 
 impl Encode for QueryResponseType {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        return self.to_u8().unwrap().encode(encoder);
+        self.to_u8().unwrap().encode(encoder)
     }
 }


### PR DESCRIPTION
this adds support for the compressed `.utracy.zst` files generated by my branch of byond-tracy-paradise: https://github.com/Absolucy/byond-tracy-paradise/tree/compression-support

support for normal uncompressed `.utracy` files is still retained - it will automatically choose which to use based on file extension

also fixes a couple of clippy lints